### PR TITLE
Feat: Create BaseEntity, User, BasicUser, AppleUser Entity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
 tasks.named('test') {

--- a/src/main/java/Honzapda/Honzapda_server/domain/AppleUser.java
+++ b/src/main/java/Honzapda/Honzapda_server/domain/AppleUser.java
@@ -1,0 +1,16 @@
+package Honzapda.Honzapda_server.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppleUser extends User{
+
+    @Column(nullable = false, length = 50)
+    private String email;
+}

--- a/src/main/java/Honzapda/Honzapda_server/domain/BasicUser.java
+++ b/src/main/java/Honzapda/Honzapda_server/domain/BasicUser.java
@@ -1,0 +1,22 @@
+package Honzapda.Honzapda_server.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BasicUser extends User{
+
+    @Column(nullable = false, length = 50)
+    private String account;
+
+    @Column(nullable = false, length = 50)
+    private String password;
+
+    @Column(nullable = false, length = 50)
+    private String email;
+}

--- a/src/main/java/Honzapda/Honzapda_server/domain/User.java
+++ b/src/main/java/Honzapda/Honzapda_server/domain/User.java
@@ -1,0 +1,31 @@
+package Honzapda.Honzapda_server.domain;
+
+import Honzapda.Honzapda_server.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Inheritance(strategy = InheritanceType.JOINED)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 50)
+    private String address;
+
+    @Column(length = 50)
+    private String address_spec;
+
+    @Column(nullable = false, length = 25)
+    private String name;
+
+    private LocalDateTime inactiveDate;
+}

--- a/src/main/java/Honzapda/Honzapda_server/domain/common/BaseEntity.java
+++ b/src/main/java/Honzapda/Honzapda_server/domain/common/BaseEntity.java
@@ -1,0 +1,21 @@
+package Honzapda.Honzapda_server.domain.common;
+
+import java.time.LocalDateTime;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## - 요약

BaseEntity와 User, BasicUser, AppleUser 엔티티 생성

<br>

## - BaseEntity

``` java
@MappedSuperclass
@EntityListeners(AuditingEntityListener.class)
@Getter
public abstract class BaseEntity {

    @CreatedDate
    private LocalDateTime createdAt;

    @LastModifiedDate
    private LocalDateTime updatedAt;
}
```

-> created_at, updated_at이 기본적으로 있다고 가정하므로, BaseEntity로 생성하였습니다.

<br>

## - User
 
``` java
@Entity
@Getter
@Builder
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@AllArgsConstructor
@Inheritance(strategy = InheritanceType.JOINED)
public class User extends BaseEntity {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @Column(length = 50)
    private String address;

    @Column(length = 50)
    private String address_spec;

    @Column(nullable = false, length = 25)
    private String name;

    private LocalDateTime inactiveDate;
}
```

-> 일단은 성문님이 작성하신 ERD를 토대로 작성해보았습니다.

<br>

## - AppleUser

``` java
@Entity
@Getter
@NoArgsConstructor
@AllArgsConstructor
public class AppleUser extends User{

    @Column(nullable = false, length = 50)
    private String email;
}
```

<br>

## - BasicUser

``` java
@Entity
@Getter
@NoArgsConstructor
@AllArgsConstructor
public class AppleUser extends User{

    @Column(nullable = false, length = 50)
    private String email;
}
```

<br>

## - 궁금한점

ERD 상에는 BasicUser와 AppleUser 엔티티가 User 엔티티를 상속받는 형식으로 작성되어있어서 상속으로 일단 구현했는데, 코드에 문제점이 혹시 있나요??

스터디 자료에서는 로그인 방법이 여러가지일 때 구조체를 사용하는 방식을 채택했는데, 왜 상속 방식을 채택하였는지 궁금합니다.