### PR TITLE
feature : add reviewList in shopResponseDto

### DIFF
--- a/src/main/java/Honzapda/Honzapda_server/review/repository/mysql/ReviewRepository.java
+++ b/src/main/java/Honzapda/Honzapda_server/review/repository/mysql/ReviewRepository.java
@@ -19,5 +19,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     void deleteAllByUser(User user);
 
     Page<Review> findAllByShopOrderByCreatedAtDesc(Shop shop, Pageable pageable);
+    List<Review> findTop3ByShopOrderByCreatedAtDesc(Shop shop);
 
 }

--- a/src/main/java/Honzapda/Honzapda_server/shop/data/dto/ShopResponseDto.java
+++ b/src/main/java/Honzapda/Honzapda_server/shop/data/dto/ShopResponseDto.java
@@ -1,6 +1,6 @@
 package Honzapda.Honzapda_server.shop.data.dto;
 
-import Honzapda.Honzapda_server.review.data.entity.Review;
+import Honzapda.Honzapda_server.review.data.dto.ReviewResponseDto;
 import Honzapda.Honzapda_server.shop.data.entity.ShopCoordinates;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -33,7 +32,7 @@ public class ShopResponseDto {
         String businessNumber;
         boolean openNow;
         LocalDateTime inactiveDate;
-        List<Review> reviewList;
+        List<ReviewResponseDto.ReviewDto> reviewList;
         List<String> photoUrls;
         List<BusinessHoursResDTO> businessHours;
 
@@ -58,6 +57,10 @@ public class ShopResponseDto {
 
         public void setBusinessHours(List<BusinessHoursResDTO> businessHours){
             this.businessHours = businessHours;
+        }
+
+        public void setReviewList(List<ReviewResponseDto.ReviewDto> reviewList){
+            this.reviewList = reviewList;
         }
     }
 


### PR DESCRIPTION
## -  변경사항

1. 특정 shop 조회(/shop/{shopId}) 결과 dto에 가게의 reviewList를 담도록 기능을 추가했습니다.

- 화면 디자인 설계도를 보니 가장 최근 리뷰 3개만 가져오는걸로 되어있어, 가장 최근 리뷰 3개만 가져오도록 기능을 작성했습니다.
  
  - 원래는 가져올 리뷰 개수를 변수로 받아오도록 구현하려 했으나, 쿼리를 작성해야 하는 등 복잡해져서 3개 고정값으로 일단 설정했습니다.

- 성문님이 구현하신 ReviewResponseDto.ReviewDto를 리스트에 담아 반환하는 형식으로 구현했습니다.

- 일단은 리뷰 리스트를 결과 dto에 set하는 형식으로 구현했습니다.

  - dto에 set하는 방식은 비추한다고 하셔서 만났을 때 수정이 필요할 것 같습니다.

<br>

## - 작성 코드

- shopServiceImpl의 getReviewListDto 함수(최하단에 위치)

``` java
   private List<ReviewResponseDto.ReviewDto> getReviewListDto(Shop shop) {

        List<Review> reviewList = reviewRepository.findTop3ByShopOrderByCreatedAtDesc(shop);

        List<ReviewResponseDto.ReviewDto> reviewDtoList = reviewList.stream()
                .map(review -> {
                    List<ReviewImage> reviewImages = reviewImageRepository
                            .findAllByReview(review).orElseThrow(()-> new GeneralException(ErrorStatus.REVIEW_NOT_FOUND));
                    return ReviewConverter.toReviewDto(review, reviewImages);
                })
                .collect(Collectors.toList());

        return reviewDtoList;
    }
```