### PR TITLE
Loading

### DIFF
--- a/src/main/java/Honzapda/Honzapda_server/apiPayload/ApiResult.java
+++ b/src/main/java/Honzapda/Honzapda_server/apiPayload/ApiResult.java
@@ -48,8 +48,5 @@ public class ApiResult<T> {
     public static <T> ApiResult<T> onFailure(BaseErrorCode code, T result){
         return new ApiResult<>(false, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(), result);
     }
-    public static <T> ApiResult<T> of(BaseErrorCode code, T result){
-        return new ApiResult<>(false, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(), result);
-    }
 
 }

--- a/src/main/java/Honzapda/Honzapda_server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/Honzapda/Honzapda_server/apiPayload/code/status/ErrorStatus.java
@@ -19,6 +19,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EMAIL_NOT_UNIQUE(HttpStatus.CONFLICT,"JOIN"+HttpStatus.CONFLICT.value(),"이미 존재하는 계정입니다."),
     NICKNAME_NOT_UNIQUE(HttpStatus.CONFLICT,"JOIN"+HttpStatus.CONFLICT.value(),"이미 존재하는 닉네임입니다."),
     // 로그인 응답
+    SESSION_EXPIRED(HttpStatus.UNAUTHORIZED,"LOGIN"+HttpStatus.UNAUTHORIZED.value(),"세션이 만료되었습니다."),
     ID_NOT_EXIST(HttpStatus.NOT_FOUND,"LOGIN"+HttpStatus.NOT_FOUND.value(),"ID를 잘못 입력하셨습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.NOT_FOUND,"LOGIN"+HttpStatus.NOT_FOUND.value(),"닉네임을 잘못 입력하셨습니다."),
     //PW_NOT_MATCH(HttpStatus.FORBIDDEN,"LOGIN"+HttpStatus.FORBIDDEN.value(),"PW를 잘못 입력하셨습니다."),

--- a/src/main/java/Honzapda/Honzapda_server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/Honzapda/Honzapda_server/apiPayload/code/status/ErrorStatus.java
@@ -21,8 +21,6 @@ public enum ErrorStatus implements BaseErrorCode {
     // 로그인 응답
     SESSION_EXPIRED(HttpStatus.UNAUTHORIZED,"LOGIN"+HttpStatus.UNAUTHORIZED.value(),"세션이 만료되었습니다."),
     ID_NOT_EXIST(HttpStatus.NOT_FOUND,"LOGIN"+HttpStatus.NOT_FOUND.value(),"ID를 잘못 입력하셨습니다."),
-    NICKNAME_NOT_EXIST(HttpStatus.NOT_FOUND,"LOGIN"+HttpStatus.NOT_FOUND.value(),"닉네임을 잘못 입력하셨습니다."),
-    //PW_NOT_MATCH(HttpStatus.FORBIDDEN,"LOGIN"+HttpStatus.FORBIDDEN.value(),"PW를 잘못 입력하셨습니다."),
     PW_NOT_MATCH(HttpStatus.FORBIDDEN,"LOGIN"+HttpStatus.FORBIDDEN.value(),"입력하신 정보가 회원정보와 일치하지 않습니다."),
 
     // 유저 응답

--- a/src/main/java/Honzapda/Honzapda_server/auth/controller/AuthController.java
+++ b/src/main/java/Honzapda/Honzapda_server/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package Honzapda.Honzapda_server.auth.controller;
 import Honzapda.Honzapda_server.apiPayload.ApiResult;
 import Honzapda.Honzapda_server.apiPayload.code.status.ErrorStatus;
 import Honzapda.Honzapda_server.apiPayload.code.status.SuccessStatus;
+import Honzapda.Honzapda_server.apiPayload.exception.GeneralException;
 import Honzapda.Honzapda_server.auth.service.AuthService;
 import Honzapda.Honzapda_server.user.data.UserConverter;
 import Honzapda.Honzapda_server.user.data.dto.*;
@@ -101,5 +102,9 @@ public class AuthController {
         }
     }
 
+    @GetMapping("/expired")
+    public void expired() {
+            throw new GeneralException(ErrorStatus.SESSION_EXPIRED);
+    }
 
 }

--- a/src/main/java/Honzapda/Honzapda_server/config/WebMvcConfig.java
+++ b/src/main/java/Honzapda/Honzapda_server/config/WebMvcConfig.java
@@ -14,6 +14,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
         registry.addInterceptor(new LoginCheckInterceptor())
                 .addPathPatterns("/**")
                 .excludePathPatterns(
+                        "/auth/expired",
                         "/auth/checkId",
                         "/auth/findId",
                         "/auth/findPassword",

--- a/src/main/java/Honzapda/Honzapda_server/intercepter/LoginCheckInterceptor.java
+++ b/src/main/java/Honzapda/Honzapda_server/intercepter/LoginCheckInterceptor.java
@@ -1,4 +1,5 @@
 package Honzapda.Honzapda_server.intercepter;
+
 import Honzapda.Honzapda_server.user.data.dto.UserResDto;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -17,7 +18,8 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
 
         // 2. 회원 정보 체크
         if (userResDto == null) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);  // 401 status code를 전송
+
+            request.getRequestDispatcher("/auth/expired").forward(request,response); // 컨트롤러로 이동해서 에러 발생
             return false;
         }
 


### PR DESCRIPTION
## - 프론트 요청사안
1️⃣ api response를 하나로 통일했으면 좋겠다고 하시네용
-> 현재 : apiResult 형태 / 사진의 response.sendError
(프론트에서 모든 response에 적용되는 기능을 만드는데 문제가 된다고 하네요.)

2️⃣ 추가로, 다른 예외처리처럼 "도메인+에러코드"로 표기 요청해주셨습니다.

## - 서버 수정 사안
1️⃣  intercepter 예외처리도 apiResult로 통일했습니다. (아직은 요거 하나 발견했습니다.)
2️⃣ LOGIN401 추가하였습니다.
3️⃣ 인터셉터 에러는 컨트롤러에서 예외처리를 해야 
     @RestControllerAdvice가 감지할 수 있다 해서, /auth/expired api 추가하였습니다.
     
삭제 : 
1. onFailure와 of가 이름만 다르고, 같은 역할을 하는 메소드여서 안쓰는 of 를 삭제했습니다.
2. 안쓰는 error status도 삭제하였습니다. 

참고 자료 : https://dev-monkey-dugi.tistory.com/136